### PR TITLE
ClassSignature::getName() returns non-empty string

### DIFF
--- a/src/ClassNameFactory.php
+++ b/src/ClassNameFactory.php
@@ -8,6 +8,9 @@ use webignition\BasilModels\Model\Test\NamedTestInterface;
 
 class ClassNameFactory
 {
+    /**
+     * @return non-empty-string
+     */
     public function create(NamedTestInterface $test): string
     {
         return sprintf('Generated%sTest', ucfirst($this->createHash($test)));

--- a/src/Model/ClassSignature.php
+++ b/src/Model/ClassSignature.php
@@ -11,15 +11,18 @@ class ClassSignature implements ResolvableInterface
     private const RENDER_TEMPLATE_WITHOUT_BASE_CLASS = 'class {{ name }}';
     private const RENDER_TEMPLATE = self::RENDER_TEMPLATE_WITHOUT_BASE_CLASS . ' extends {{ base_class }}';
 
-    private string $name;
-    private ?ClassName $baseClass;
-
-    public function __construct(string $name, ?ClassName $baseClass = null)
-    {
-        $this->name = $name;
-        $this->baseClass = $baseClass;
+    /**
+     * @param non-empty-string $name
+     */
+    public function __construct(
+        private readonly string $name,
+        private readonly ?ClassName $baseClass = null
+    ) {
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getName(): string
     {
         return $this->name;


### PR DESCRIPTION
Fixes #618