### PR TITLE
Assertion handler test methods do not need to be passed metadata

### DIFF
--- a/tests/DataProvider/Assertion/CreateFromExcludesAssertionDataProviderTrait.php
+++ b/tests/DataProvider/Assertion/CreateFromExcludesAssertionDataProviderTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSourceFactory\Tests\DataProvider\Assertion;
 
 use webignition\BasilCompilableSourceFactory\Enum\VariableName;
-use webignition\BasilCompilableSourceFactory\Metadata\Metadata as TestMetadata;
 use webignition\BasilCompilableSourceFactory\Model\Metadata\Metadata;
-use webignition\BasilModels\Model\Assertion\AssertionInterface;
 use webignition\BasilModels\Parser\AssertionParser;
 
 trait CreateFromExcludesAssertionDataProviderTrait
@@ -22,17 +20,6 @@ trait CreateFromExcludesAssertionDataProviderTrait
         return [
             'excludes comparison, element identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".selector" excludes "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" excludes "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = (function () {
@@ -60,17 +47,6 @@ trait CreateFromExcludesAssertionDataProviderTrait
             ],
             'excludes comparison, attribute identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".selector".attribute_name excludes "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector".attribute_name excludes "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = (function () {

--- a/tests/DataProvider/Assertion/CreateFromIdentifierExistsAssertionDataProviderTrait.php
+++ b/tests/DataProvider/Assertion/CreateFromIdentifierExistsAssertionDataProviderTrait.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSourceFactory\Tests\DataProvider\Assertion;
 
 use webignition\BasilCompilableSourceFactory\Enum\VariableName;
-use webignition\BasilCompilableSourceFactory\Metadata\Metadata as TestMetadata;
 use webignition\BasilCompilableSourceFactory\Model\Metadata\Metadata;
-use webignition\BasilModels\Model\Action\ActionInterface;
-use webignition\BasilModels\Model\Assertion\AssertionInterface;
 use webignition\BasilModels\Model\Assertion\DerivedValueOperationAssertion;
 use webignition\BasilModels\Parser\ActionParser;
 use webignition\BasilModels\Parser\AssertionParser;
@@ -37,17 +34,6 @@ trait CreateFromIdentifierExistsAssertionDataProviderTrait
         return [
             'exists comparison, element identifier examined value' => [
                 'assertion' => $assertionParser->parse('$".selector" exists'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" exists')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     try {
                         $examinedValue = {{ NAVIGATOR }}->has('{
@@ -67,17 +53,6 @@ trait CreateFromIdentifierExistsAssertionDataProviderTrait
             ],
             'exists comparison, attribute identifier examined value' => [
                 'assertion' => $assertionParser->parse('$".selector".attribute_name exists'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector".attribute_name exists')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     try {
                         $examinedValue = {{ NAVIGATOR }}->hasOne('{
@@ -110,17 +85,6 @@ trait CreateFromIdentifierExistsAssertionDataProviderTrait
             ],
             'exists comparison, css attribute selector containing dot' => [
                 'assertion' => $assertionParser->parse('$"a[href=foo.html]" exists'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$"a[href=foo.html]" exists')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     try {
                         $examinedValue = {{ NAVIGATOR }}->has('{
@@ -140,17 +104,6 @@ trait CreateFromIdentifierExistsAssertionDataProviderTrait
             ],
             'exists comparison, css attribute selector containing dot with attribute name' => [
                 'assertion' => $assertionParser->parse('$"a[href=foo.html]".attribute_name exists'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$"a[href=foo.html]".attribute_name exists')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     try {
                         $examinedValue = {{ NAVIGATOR }}->hasOne('{
@@ -187,28 +140,6 @@ trait CreateFromIdentifierExistsAssertionDataProviderTrait
                     '$".selector"',
                     'exists'
                 ),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $action = \Mockery::mock(ActionInterface::class);
-                        $action
-                            ->shouldReceive('__toString')
-                            ->andReturn('click $".selector"')
-                        ;
-
-                        $assertion = \Mockery::mock(DerivedValueOperationAssertion::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" exists')
-                        ;
-
-                        $assertion
-                            ->shouldReceive('getSourceStatement')
-                            ->andReturn($action)
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     try {
                         $examinedValue = {{ NAVIGATOR }}->hasOne('{
@@ -232,28 +163,6 @@ trait CreateFromIdentifierExistsAssertionDataProviderTrait
                     $actionParser->parse('submit $".selector"'),
                     '$".selector"',
                     'exists'
-                ),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $action = \Mockery::mock(ActionInterface::class);
-                        $action
-                            ->shouldReceive('__toString')
-                            ->andReturn('submit $".selector"')
-                        ;
-
-                        $assertion = \Mockery::mock(DerivedValueOperationAssertion::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" exists')
-                        ;
-
-                        $assertion
-                            ->shouldReceive('getSourceStatement')
-                            ->andReturn($action)
-                        ;
-
-                        return $assertion;
-                    })(),
                 ),
                 'expectedRenderedContent' => <<<'EOD'
                     try {
@@ -279,28 +188,6 @@ trait CreateFromIdentifierExistsAssertionDataProviderTrait
                     '$".selector"',
                     'exists'
                 ),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $action = \Mockery::mock(ActionInterface::class);
-                        $action
-                            ->shouldReceive('__toString')
-                            ->andReturn('set $".selector" to "value"')
-                        ;
-
-                        $assertion = \Mockery::mock(DerivedValueOperationAssertion::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" exists')
-                        ;
-
-                        $assertion
-                            ->shouldReceive('getSourceStatement')
-                            ->andReturn($action)
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     try {
                         $examinedValue = {{ NAVIGATOR }}->has('{
@@ -324,28 +211,6 @@ trait CreateFromIdentifierExistsAssertionDataProviderTrait
                     $actionParser->parse('wait $".duration"'),
                     '$".duration"',
                     'exists'
-                ),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $action = \Mockery::mock(ActionInterface::class);
-                        $action
-                            ->shouldReceive('__toString')
-                            ->andReturn('wait $".duration"')
-                        ;
-
-                        $assertion = \Mockery::mock(DerivedValueOperationAssertion::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".duration" exists')
-                        ;
-
-                        $assertion
-                            ->shouldReceive('getSourceStatement')
-                            ->andReturn($action)
-                        ;
-
-                        return $assertion;
-                    })(),
                 ),
                 'expectedRenderedContent' => <<<'EOD'
                     try {

--- a/tests/DataProvider/Assertion/CreateFromIdentifierNotExistsAssertionDataProviderTrait.php
+++ b/tests/DataProvider/Assertion/CreateFromIdentifierNotExistsAssertionDataProviderTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSourceFactory\Tests\DataProvider\Assertion;
 
 use webignition\BasilCompilableSourceFactory\Enum\VariableName;
-use webignition\BasilCompilableSourceFactory\Metadata\Metadata as TestMetadata;
 use webignition\BasilCompilableSourceFactory\Model\Metadata\Metadata;
-use webignition\BasilModels\Model\Assertion\AssertionInterface;
 use webignition\BasilModels\Parser\AssertionParser;
 use webignition\SymfonyDomCrawlerNavigator\Exception\InvalidLocatorException;
 
@@ -33,17 +31,6 @@ trait CreateFromIdentifierNotExistsAssertionDataProviderTrait
         return [
             'not-exists comparison, element identifier examined value' => [
                 'assertion' => $assertionParser->parse('$".selector" not-exists'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" not-exists')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     try {
                         $examinedValue = {{ NAVIGATOR }}->has('{
@@ -63,17 +50,6 @@ trait CreateFromIdentifierNotExistsAssertionDataProviderTrait
             ],
             'not-exists comparison, attribute identifier examined value' => [
                 'assertion' => $assertionParser->parse('$".selector".attribute_name not-exists'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector".attribute_name not-exists')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     try {
                         $examinedValue = {{ NAVIGATOR }}->hasOne('{

--- a/tests/DataProvider/Assertion/CreateFromIncludesAssertionDataProviderTrait.php
+++ b/tests/DataProvider/Assertion/CreateFromIncludesAssertionDataProviderTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSourceFactory\Tests\DataProvider\Assertion;
 
 use webignition\BasilCompilableSourceFactory\Enum\VariableName;
-use webignition\BasilCompilableSourceFactory\Metadata\Metadata as TestMetadata;
 use webignition\BasilCompilableSourceFactory\Model\Metadata\Metadata;
-use webignition\BasilModels\Model\Assertion\AssertionInterface;
 use webignition\BasilModels\Parser\AssertionParser;
 
 trait CreateFromIncludesAssertionDataProviderTrait
@@ -22,17 +20,6 @@ trait CreateFromIncludesAssertionDataProviderTrait
         return [
             'includes comparison, element identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".selector" includes "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" includes "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = (function () {
@@ -60,17 +47,6 @@ trait CreateFromIncludesAssertionDataProviderTrait
             ],
             'includes comparison, attribute identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".selector".attribute_name includes "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector".attribute_name includes "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = (function () {

--- a/tests/DataProvider/Assertion/CreateFromIsAssertionDataProviderTrait.php
+++ b/tests/DataProvider/Assertion/CreateFromIsAssertionDataProviderTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSourceFactory\Tests\DataProvider\Assertion;
 
 use webignition\BasilCompilableSourceFactory\Enum\VariableName;
-use webignition\BasilCompilableSourceFactory\Metadata\Metadata as TestMetadata;
 use webignition\BasilCompilableSourceFactory\Model\Metadata\Metadata;
-use webignition\BasilModels\Model\Assertion\AssertionInterface;
 use webignition\BasilModels\Parser\AssertionParser;
 
 trait CreateFromIsAssertionDataProviderTrait
@@ -22,17 +20,6 @@ trait CreateFromIsAssertionDataProviderTrait
         return [
             'is comparison, element identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".selector" is "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" is "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = (function () {
@@ -60,17 +47,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, descendant identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".parent" >> $".child" is "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".parent" >> $".child" is "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = (function () {
@@ -101,17 +77,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, attribute identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".selector".attribute_name is "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector".attribute_name is "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = (function () {
@@ -138,17 +103,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, browser object examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$browser.size is "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$browser.size is "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
             $expectedValue = "value" ?? null;
             $examinedValue = (function () {
@@ -173,17 +127,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, environment examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$env.KEY is "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$env.KEY is "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = {{ ENV }}['KEY'] ?? null;
@@ -204,17 +147,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, environment examined value with default, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$env.KEY|"default value" is "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$env.KEY|"default value" is "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = {{ ENV }}['KEY'] ?? 'default value';
@@ -235,17 +167,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, environment examined value with default, environment examined value with default' => [
                 'assertion' => $assertionParser->parse('$env.KEY1|"default value 1" is $env.KEY2|"default value 2"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$env.KEY1|"default value 1" is $env.KEY2|"default value 2"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = {{ ENV }}['KEY2'] ?? 'default value 2';
                     $examinedValue = {{ ENV }}['KEY1'] ?? 'default value 1';
@@ -266,17 +187,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, page object examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$page.title is "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$page.title is "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = {{ CLIENT }}->getTitle() ?? null;
@@ -297,17 +207,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, browser object examined value, descendant identifier expected value' => [
                 'assertion' => $assertionParser->parse('$browser.size is $".parent" >> $".child"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$browser.size is $".parent" >> $".child"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
             $expectedValue = (function () {
                 $element = {{ NAVIGATOR }}->find('{
@@ -343,17 +242,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, browser object examined value, element identifier expected value' => [
                 'assertion' => $assertionParser->parse('$browser.size is $".selector"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$browser.size is $".selector"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
             $expectedValue = (function () {
                 $element = {{ NAVIGATOR }}->find('{
@@ -386,17 +274,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, browser object examined value, attribute identifier expected value' => [
                 'assertion' => $assertionParser->parse('$browser.size is $".selector".attribute_name'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$browser.size is $".selector".attribute_name')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
             $expectedValue = (function () {
                 $element = {{ NAVIGATOR }}->findOne('{
@@ -428,17 +305,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, browser object examined value, environment expected value' => [
                 'assertion' => $assertionParser->parse('$browser.size is $env.KEY'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$browser.size is $env.KEY')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
             $expectedValue = {{ ENV }}['KEY'] ?? null;
             $examinedValue = (function () {
@@ -464,17 +330,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, browser object examined value, environment expected value with default' => [
                 'assertion' => $assertionParser->parse('$browser.size is $env.KEY|"default value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$browser.size is $env.KEY|"default value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
             $expectedValue = {{ ENV }}['KEY'] ?? 'default value';
             $examinedValue = (function () {
@@ -500,17 +355,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, browser object examined value, page object expected value' => [
                 'assertion' => $assertionParser->parse('$browser.size is $page.url'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$browser.size is $env.KEY|"default value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
             $expectedValue = {{ CLIENT }}->getCurrentURL() ?? null;
             $examinedValue = (function () {
@@ -522,7 +366,7 @@ trait CreateFromIsAssertionDataProviderTrait
                 $expectedValue,
                 $examinedValue,
                 '{
-                    "assertion": "$browser.size is $env.KEY|\\"default value\\""
+                    "assertion": "$browser.size is $page.url"
                 }'
             );
             EOD,
@@ -535,17 +379,6 @@ trait CreateFromIsAssertionDataProviderTrait
             ],
             'is comparison, literal string examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('"examined" is "expected"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('"examined" is "expected"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "expected" ?? null;
                     $examinedValue = "examined" ?? null;

--- a/tests/DataProvider/Assertion/CreateFromIsNotAssertionDataProviderTrait.php
+++ b/tests/DataProvider/Assertion/CreateFromIsNotAssertionDataProviderTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSourceFactory\Tests\DataProvider\Assertion;
 
 use webignition\BasilCompilableSourceFactory\Enum\VariableName;
-use webignition\BasilCompilableSourceFactory\Metadata\Metadata as TestMetadata;
 use webignition\BasilCompilableSourceFactory\Model\Metadata\Metadata;
-use webignition\BasilModels\Model\Assertion\AssertionInterface;
 use webignition\BasilModels\Parser\AssertionParser;
 
 trait CreateFromIsNotAssertionDataProviderTrait
@@ -22,17 +20,6 @@ trait CreateFromIsNotAssertionDataProviderTrait
         return [
             'is-not comparison, element identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".selector" is-not "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" is-not "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = (function () {
@@ -60,17 +47,6 @@ trait CreateFromIsNotAssertionDataProviderTrait
             ],
             'is-not comparison, attribute identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".selector".attribute_name is-not "value"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector".attribute_name is-not "value"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "value" ?? null;
                     $examinedValue = (function () {

--- a/tests/DataProvider/Assertion/CreateFromIsRegExpAssertionDataProviderTrait.php
+++ b/tests/DataProvider/Assertion/CreateFromIsRegExpAssertionDataProviderTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSourceFactory\Tests\DataProvider\Assertion;
 
 use webignition\BasilCompilableSourceFactory\Enum\VariableName;
-use webignition\BasilCompilableSourceFactory\Metadata\Metadata as TestMetadata;
 use webignition\BasilCompilableSourceFactory\Model\Metadata\Metadata;
-use webignition\BasilModels\Model\Assertion\AssertionInterface;
 use webignition\BasilModels\Model\Assertion\DerivedValueOperationAssertion;
 use webignition\BasilModels\Parser\AssertionParser;
 
@@ -27,24 +25,14 @@ trait CreateFromIsRegExpAssertionDataProviderTrait
                     '"/^value/"',
                     'is-regexp'
                 ),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" matches "/^value/"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $examinedValue = "/^value/" ?? null;
                     $expectedValue = @preg_match($examinedValue, null) === false;
                     {{ PHPUNIT }}->assertFalse(
                         $expectedValue,
                         '{
-                            "assertion": "$\\".selector\\" matches \\"\\/^value\\/\\""
+                            "assertion": "\\"\\/^value\\/\\" is-regexp",
+                            "source": "$\\".selector\\" matches \\"\\/^value\\/\\""
                         }'
                     );
                     EOD,
@@ -60,17 +48,6 @@ trait CreateFromIsRegExpAssertionDataProviderTrait
                     '$".pattern-container"',
                     'is-regexp'
                 ),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" matches $".pattern-container"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $examinedValue = (function () {
                         $element = {{ NAVIGATOR }}->find('{
@@ -83,7 +60,8 @@ trait CreateFromIsRegExpAssertionDataProviderTrait
                     {{ PHPUNIT }}->assertFalse(
                         $expectedValue,
                         '{
-                            "assertion": "$\\".selector\\" matches $\\".pattern-container\\""
+                            "assertion": "$\\".pattern-container\\" is-regexp",
+                            "source": "$\\".selector\\" matches $\\".pattern-container\\""
                         }'
                     );
                     EOD,
@@ -101,17 +79,6 @@ trait CreateFromIsRegExpAssertionDataProviderTrait
                     '$".pattern-container".attribute_name',
                     'is-regexp'
                 ),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" matches $".pattern-container".attribute_name')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $examinedValue = (function () {
                         $element = {{ NAVIGATOR }}->findOne('{
@@ -124,7 +91,8 @@ trait CreateFromIsRegExpAssertionDataProviderTrait
                     {{ PHPUNIT }}->assertFalse(
                         $expectedValue,
                         '{
-                            "assertion": "$\\".selector\\" matches $\\".pattern-container\\".attribute_name"
+                            "assertion": "$\\".pattern-container\\".attribute_name is-regexp",
+                            "source": "$\\".selector\\" matches $\\".pattern-container\\".attribute_name"
                         }'
                     );
                     EOD,
@@ -141,24 +109,14 @@ trait CreateFromIsRegExpAssertionDataProviderTrait
                     '$data.pattern',
                     'is-regexp'
                 ),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$page.title matches $data.pattern')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $examinedValue = $pattern ?? null;
                     $expectedValue = @preg_match($examinedValue, null) === false;
                     {{ PHPUNIT }}->assertFalse(
                         $expectedValue,
                         '{
-                            "assertion": "$page.title matches $data.pattern"
+                            "assertion": "$data.pattern is-regexp",
+                            "source": "$page.title matches $data.pattern"
                         }'
                     );
                     EOD,

--- a/tests/DataProvider/Assertion/CreateFromMatchesAssertionDataProviderTrait.php
+++ b/tests/DataProvider/Assertion/CreateFromMatchesAssertionDataProviderTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSourceFactory\Tests\DataProvider\Assertion;
 
 use webignition\BasilCompilableSourceFactory\Enum\VariableName;
-use webignition\BasilCompilableSourceFactory\Metadata\Metadata as TestMetadata;
 use webignition\BasilCompilableSourceFactory\Model\Metadata\Metadata;
-use webignition\BasilModels\Model\Assertion\AssertionInterface;
 use webignition\BasilModels\Parser\AssertionParser;
 
 trait CreateFromMatchesAssertionDataProviderTrait
@@ -22,17 +20,6 @@ trait CreateFromMatchesAssertionDataProviderTrait
         return [
             'matches comparison, element identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".selector" matches "/^value/"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector" matches "/^value/"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "/^value/" ?? null;
                     $examinedValue = (function () {
@@ -60,17 +47,6 @@ trait CreateFromMatchesAssertionDataProviderTrait
             ],
             'matches comparison, attribute identifier examined value, literal string expected value' => [
                 'assertion' => $assertionParser->parse('$".selector".attribute_name matches "/^value/"'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$".selector".attribute_name matches "/^value/"')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     $expectedValue = "/^value/" ?? null;
                     $examinedValue = (function () {

--- a/tests/DataProvider/Assertion/CreateFromScalarExistsAssertionDataProviderTrait.php
+++ b/tests/DataProvider/Assertion/CreateFromScalarExistsAssertionDataProviderTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSourceFactory\Tests\DataProvider\Assertion;
 
 use webignition\BasilCompilableSourceFactory\Enum\VariableName;
-use webignition\BasilCompilableSourceFactory\Metadata\Metadata as TestMetadata;
 use webignition\BasilCompilableSourceFactory\Model\Metadata\Metadata;
-use webignition\BasilModels\Model\Assertion\AssertionInterface;
 use webignition\BasilModels\Parser\AssertionParser;
 
 trait CreateFromScalarExistsAssertionDataProviderTrait
@@ -22,17 +20,6 @@ trait CreateFromScalarExistsAssertionDataProviderTrait
         return [
             'exists comparison, page property examined value' => [
                 'assertion' => $assertionParser->parse('$page.url exists'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$page.url exists')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     {{ PHPUNIT }}->assertTrue(
                         ({{ CLIENT }}->getCurrentURL() ?? null) !== null,
@@ -50,17 +37,6 @@ trait CreateFromScalarExistsAssertionDataProviderTrait
             ],
             'exists comparison, data parameter value' => [
                 'assertion' => $assertionParser->parse('$data.key exists'),
-                'metadata' => new TestMetadata(
-                    (function () {
-                        $assertion = \Mockery::mock(AssertionInterface::class);
-                        $assertion
-                            ->shouldReceive('__toString')
-                            ->andReturn('$data.key exists')
-                        ;
-
-                        return $assertion;
-                    })(),
-                ),
                 'expectedRenderedContent' => <<<'EOD'
                     {{ PHPUNIT }}->assertTrue(
                         ($key ?? null) !== null,

--- a/tests/Unit/Handler/Assertion/ComparisonAssertionHandlerTest.php
+++ b/tests/Unit/Handler/Assertion/ComparisonAssertionHandlerTest.php
@@ -35,13 +35,12 @@ class ComparisonAssertionHandlerTest extends AbstractResolvableTestCase
      */
     public function testHandle(
         AssertionInterface $assertion,
-        Metadata $metadata,
         string $expectedRenderedContent,
         MetadataInterface $expectedMetadata
     ): void {
         $handler = ComparisonAssertionHandler::createHandler();
 
-        $source = $handler->handle($assertion, $metadata);
+        $source = $handler->handle($assertion, new Metadata($assertion));
 
         $this->assertRenderResolvable($expectedRenderedContent, $source);
         $this->assertEquals($expectedMetadata, $source->getMetadata());
@@ -63,9 +62,7 @@ class ComparisonAssertionHandlerTest extends AbstractResolvableTestCase
 
         $this->expectExceptionObject($expectedException);
 
-        $metadata = new Metadata($assertion);
-
-        $handler->handle($assertion, $metadata);
+        $handler->handle($assertion, new Metadata($assertion));
     }
 
     /**

--- a/tests/Unit/Handler/Assertion/IdentifierExistsAssertionHandlerTest.php
+++ b/tests/Unit/Handler/Assertion/IdentifierExistsAssertionHandlerTest.php
@@ -26,13 +26,12 @@ class IdentifierExistsAssertionHandlerTest extends AbstractResolvableTestCase
      */
     public function testHandle(
         AssertionInterface $assertion,
-        Metadata $metadata,
         string $expectedRenderedContent,
         MetadataInterface $expectedMetadata
     ): void {
         $handler = IdentifierExistenceAssertionHandler::createHandler();
 
-        $source = $handler->handle($assertion, $metadata);
+        $source = $handler->handle($assertion, new Metadata($assertion));
 
         $this->assertRenderResolvable($expectedRenderedContent, $source);
         $this->assertEquals($expectedMetadata, $source->getMetadata());

--- a/tests/Unit/Handler/Assertion/IsRegExpAssertionHandlerTest.php
+++ b/tests/Unit/Handler/Assertion/IsRegExpAssertionHandlerTest.php
@@ -20,13 +20,12 @@ class IsRegExpAssertionHandlerTest extends AbstractResolvableTestCase
      */
     public function testHandle(
         AssertionInterface $assertion,
-        Metadata $metadata,
         string $expectedRenderedContent,
         MetadataInterface $expectedMetadata
     ): void {
         $handler = IsRegExpAssertionHandler::createHandler();
 
-        $source = $handler->handle($assertion, $metadata);
+        $source = $handler->handle($assertion, new Metadata($assertion));
 
         $this->assertRenderResolvable($expectedRenderedContent, $source);
         $this->assertEquals($expectedMetadata, $source->getMetadata());

--- a/tests/Unit/Handler/Assertion/ScalarExistenceAssertionHandlerTest.php
+++ b/tests/Unit/Handler/Assertion/ScalarExistenceAssertionHandlerTest.php
@@ -20,13 +20,12 @@ class ScalarExistenceAssertionHandlerTest extends AbstractResolvableTestCase
      */
     public function testHandle(
         AssertionInterface $assertion,
-        Metadata $metadata,
         string $expectedRenderedContent,
         MetadataInterface $expectedMetadata
     ): void {
         $handler = ScalarExistenceAssertionHandler::createHandler();
 
-        $source = $handler->handle($assertion, $metadata);
+        $source = $handler->handle($assertion, new Metadata($assertion));
 
         $this->assertRenderResolvable($expectedRenderedContent, $source);
         $this->assertEquals($expectedMetadata, $source->getMetadata());


### PR DESCRIPTION
Fixes #757